### PR TITLE
add availability to CTA section

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ I'm developing this site for free as a favour, and in exchange, the business own
 Current design is MVP; logo and colour palette were pre-existing, and things like spacing and fonts can be greatly improved. The client has asked for my help refreshing all branding with their input after the initial launch (getting deployed and indexed by search engines is priority).
 
 ## Roadmap (roughly prioritised)
-* add opening hours / availability somewhere
 * figure out better responsive image handling to reduce payloads
 * headings - move responsive max width logic to wrapper elements, headings always full width 
 * add faq page

--- a/components/SiteCTASection/SiteCTASection.tsx
+++ b/components/SiteCTASection/SiteCTASection.tsx
@@ -1,5 +1,5 @@
 import Section from '@/components/Section/Section';
-import { H2 } from '@/components/Heading/Heading';
+import { H2, H3 } from '@/components/Heading/Heading';
 import ButtonLink from '@/components/ButtonLink/ButtonLink';
 import Link from 'next/link';
 
@@ -20,6 +20,8 @@ export default function SiteCTASection() {
             a DM telling me what you&apos;d like and your preferred date and time, and I&apos;ll get
             you booked in ASAP.
           </p>
+          <H3 variant='h4'>Opening hours: Mon - Sat, 9:00am - late (6pm last appointment)</H3>
+          <p>Appointments outside these hours are available by prior arrangement and will incur a small fee.</p>
         </Section.Column>
         <Section.Column>
           <ul className="self-center flex flex-col items-stretch w-full p-0 my-0 list-none">


### PR DESCRIPTION
# What's changed?
* Add opening hours (as header for improved SEO)

<img width="938" alt="Screenshot 2023-09-26 at 9 34 01 pm" src="https://github.com/bootlegneurons/tdn-web-next/assets/37989995/ac7b9b6c-3d66-4621-8a1c-3040d0183c4c">
