### PR TITLE
Fix/header alignment

### DIFF
--- a/components/Heading/Heading.tsx
+++ b/components/Heading/Heading.tsx
@@ -28,9 +28,9 @@ const Heading = ({
   className: mergeClasses,
 }: HeadingProps) => {
   const Element = as || 'h2';
-  const baseStyles = 'font-heading mb-5 tracking-wide leading-none md:max-w-xl md:leading-tight';
+  const baseStyles = 'font-heading mb-5 tracking-wide leading-none md:leading-tight';
   const variantStyles: { [k in HeadingVariant]?: string } = {
-    h1: 'font-normal text-4xl uppercase md:text-5xl md:max-w-md lg:max-w-sm',
+    h1: 'font-normal text-4xl uppercase md:text-5xl',
     h2: 'font-normal mb-2 text-3xl md:mb-3 md:text-4xl',
     h3: 'font-light mb-2 text-xl md:mb-3 md:text-2xl',
     h4: 'font-normal mb-1 text-sm uppercase md:mb-2 md:text-base',

--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -23,18 +23,18 @@ const HeroInner = ({ expanded, flipped, heading, subtitle, feature }: HeroInnerP
   return (
     <header
       className={twMerge(
-        'flex flex-col items-center justify-between gap-4 mx-auto px-8 py-8 lg:flex-row lg:w-[978px] lg:px-4 lg:py-16',
+        'flex flex-col items-center justify-between gap-4 mx-auto px-8 py-4 lg:flex-row lg:w-[978px] lg:px-4 lg:py-16',
         expanded && 'lg:mt-[-56px] lg:h-screen',
       )}
     >
       <div
         className={twMerge(
-          'grow-0 w-full text-center md:text-left',
+          'grow-0 w-full text-center lg:text-left',
           feature ? 'max-w-xs' : 'max-w-full', // Full width content area if no feature
           feature && flipped && 'lg:order-last' // Put content after feature if flag true
         )}
       >
-        <H1 className={feature ? 'md:max-w-full md:text-center' : 'md:max-w-lg'}>{heading}</H1>
+        <H1>{heading}</H1>
         {subtitle && (
           <p
             className="pt-6 font-heading tracking-wide text-2xl font-normal text-center lg:text-left"


### PR DESCRIPTION
# What's changed?

Headers were not correctly aligned sometimes (e.g. in header at medium breakpoint). Simplified the styles to fix this issue. Applying max width to headers should be opt-in and done contextually in the wrapping element.

## Screenshot

<img width="979" alt="Screenshot 2023-09-26 at 9 45 36 pm" src="https://github.com/bootlegneurons/tdn-web-next/assets/37989995/5b29e0cb-f5ed-4463-b914-2614b8343861">
