### PR TITLE
Feat/serp listing improvements

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -8,9 +8,9 @@ import Hero from '@/components/Hero/Hero';
 import imgSelina from '@/public/selina-about-me.webp';
 
 export const metadata: Metadata = {
-  title: 'The Dreamy Nails | About me',
+  title: 'About The Dreamy Nails',
   description:
-    "It's nice to meet you! Let me tell you a little about myself and my private home salon.",
+    "About my home nail salon journey. Understand why creating a safe space to express yourself is so important to me",
 };
 
 export default function AboutMe() {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,71 +7,75 @@ import Container from '@/components/Container/Container';
 import Hero from '@/components/Hero/Hero';
 import ButtonLink from '@/components/ButtonLink/ButtonLink';
 import SiteInstagramGallery from '@/components/SiteInstagramGallery/SiteInstagramGallery';
+import SiteJsonLd from '@/components/SiteJsonLd/SiteJsonLd';
 import SiteLogoFull from '@/components/icons/SiteLogoFull';
 
 import tdnHeroSamples from '@/public/tdn-hero-samples.webp';
 import tdnFeatureImg from '@/public/pastel-princess-nail-design.webp';
 
 export const metadata: Metadata = {
-  title: 'The Dreamy Nails Sydney | BIAB, nail art, manicures and press-on nails',
+  title: 'Sydney BIAB nail art, manicures & press-ons by The Dreamy Nails',
   description:
-    "I'm a nail artist creating beautiful hand-painted nail designs from my private home salon in Erskineville",
+    "I'm creating beautiful hand-painted nail art from my private home nail salon in Sydney",
 };
 
 export default function Home() {
   return (
-    <div className="grow">
-      <Hero
-        expanded
-        heading={<SiteLogoFull width={300} />}
-        subtitle="I'm creating beautiful hand-painted nail designs from my private home salon in Erskineville. My services include BIAB, GELX, e-file manicure, press-on nails, and more."
-        feature={
-          <Image
-            src={tdnHeroSamples}
-            alt="Photos of beautiful hand-painted nail designs by Selina from The Dreamy Nails nail salon, Sydney"
-            priority
-            quality={100}
-            placeholder="blur"
-          />
-        }
-      />
-
-      <Container>
-        <Section>
-          <Section.Column doubleWidth>
-            <H2 variant="h1">Welcome to The Dreamy Nails</H2>
-            <p>
-              Hello! I&apos;m Selina, a nail artist working from my private and comfortable home
-              studio. I love turning ordinary nails into works of art!
-            </p>
-            <p>
-              I&apos;m conveniently-located in Erskineville, Sydney — close to public transport, and
-              walking distance from Newtown and Redfern.
-            </p>
-            <p>Do you want to know more about my salon and my journey with nail art?</p>
-            <div>
-              <ButtonLink href="/about" variant="subtle">
-                Read more
-              </ButtonLink>
-            </div>
-          </Section.Column>
-          <Section.Column>
+    <>
+      <SiteJsonLd />
+      <div className="grow">
+        <Hero
+          expanded
+          heading={<SiteLogoFull width={300} />}
+          subtitle="I'm creating beautiful hand-painted nail designs from my private home salon in Erskineville. My services include BIAB, GELX, e-file manicure, press-on nails, and more."
+          feature={
             <Image
-              src={tdnFeatureImg}
-              alt="Pastel princess-themed hand painted nail designs by The Dreamy Nails in Sydney"
-              width={350}
-              height={350}
-              className="mx-auto"
+              src={tdnHeroSamples}
+              alt="Photos of beautiful hand-painted nail designs by Selina from The Dreamy Nails nail salon, Sydney"
+              priority
+              quality={100}
+              placeholder="blur"
             />
+          }
+        />
+
+        <Container>
+          <Section>
+            <Section.Column doubleWidth>
+              <H2 variant="h1">Welcome to The Dreamy Nails</H2>
+              <p>
+                Hello! I&apos;m Selina, a nail artist working from my private and comfortable home
+                studio. I love turning ordinary nails into works of art!
+              </p>
+              <p>
+                I&apos;m conveniently-located in Erskineville, Sydney — close to public transport,
+                and walking distance from Newtown and Redfern.
+              </p>
+              <p>Do you want to know more about my salon and my journey with nail art?</p>
+              <div>
+                <ButtonLink href="/about" variant="subtle">
+                  Read more
+                </ButtonLink>
+              </div>
+            </Section.Column>
+            <Section.Column>
+              <Image
+                src={tdnFeatureImg}
+                alt="Pastel princess-themed hand painted nail designs by The Dreamy Nails in Sydney"
+                width={350}
+                height={350}
+                className="mx-auto"
+              />
+            </Section.Column>
+          </Section>
+        </Container>
+        <Section>
+          <Section.Column>
+            <H2>My latest nail art</H2>
+            <SiteInstagramGallery />
           </Section.Column>
         </Section>
-      </Container>
-      <Section>
-        <Section.Column>
-          <H2>My latest nail art</H2>
-          <SiteInstagramGallery />
-        </Section.Column>
-      </Section>
-    </div>
+      </div>
+    </>
   );
 }

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -5,8 +5,8 @@ import Heading, { H2, H3, H4 } from '@/components/Heading/Heading';
 import Hero from '@/components/Hero/Hero';
 
 export const metadata: Metadata = {
-  title: 'The Dreamy Nails | Service menu',
-  description: 'Get an idea of my current nail services, and how much your appointment will cost.',
+  title: 'Service menu | The Dreamy Nails',
+  description: 'My individually-tailored services include BIAB manicures, bespoke nail art, soft gel extensions & more',
 };
 
 /** 

--- a/components/SiteJsonLd/SiteJsonLd.tsx
+++ b/components/SiteJsonLd/SiteJsonLd.tsx
@@ -1,0 +1,42 @@
+import type { WithContext, WebSite, NailSalon } from 'schema-dts';
+
+const webSiteJsonLD: WithContext<WebSite> = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: 'The Dreamy Nails',
+  description: 'Sydney BIAB nail art, manicures & press-ons',
+};
+
+const nailSalonJsonLD: NailSalon = {
+  '@type': 'NailSalon',
+  name: 'The Dreamy Nails',
+  description: 'Sydney BIAB nail art, manicures & press-ons',
+  location: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Sydney',
+    addressRegion: 'NSW',
+    addressCountry: 'AU',
+    postalCode: '2043',
+  },
+};
+
+/*
+  NOTE: this should only be included once on the root page, child pages will need their own customisations e.g. for image galleries, product pages, etc.
+
+  The popular `next-seo` package doesn't support the WebSite type, so decided to just implement this manually for now. It's manageable because it's currently only needed on one page, will need some abstraction eventually.
+
+*/
+export default function SiteJsonLd() {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(webSiteJsonLD) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(nailSalonJsonLD) }}
+      />
+    </>
+  );
+}

--- a/components/SiteJsonLd/SiteJsonLd.tsx
+++ b/components/SiteJsonLd/SiteJsonLd.tsx
@@ -18,6 +18,7 @@ const nailSalonJsonLD: NailSalon = {
     addressCountry: 'AU',
     postalCode: '2043',
   },
+  openingHours: "Mo-Sa 09:00-18:00",
 };
 
 /*

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "postcss": "8.4.30",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "schema-dts": "^1.1.2",
     "tailwind-merge": "^1.14.0",
     "tailwindcss": "3.3.3",
     "typescript": "5.2.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ dependencies:
   react-dom:
     specifier: 18.2.0
     version: 18.2.0(react@18.2.0)
+  schema-dts:
+    specifier: ^1.1.2
+    version: 1.1.2(typescript@5.2.2)
   tailwind-merge:
     specifier: ^1.14.0
     version: 1.14.0
@@ -2428,6 +2431,14 @@ packages:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
     dependencies:
       loose-envify: 1.4.0
+    dev: false
+
+  /schema-dts@1.1.2(typescript@5.2.2):
+    resolution: {integrity: sha512-MpNwH0dZJHinVxk9bT8XUdjKTxMYrA5bLtrrGmFA6PTLwlOKnhi67XoRd6/ty+Djt6ZC0slR57qFhZDNMI6DhQ==}
+    peerDependencies:
+      typescript: '>=4.1.0'
+    dependencies:
+      typescript: 5.2.2
     dev: false
 
   /semver@6.3.1:


### PR DESCRIPTION
# What's changed?

Implements issue: #10 

* Added 'WebSite' structured data - this should improve the visual display of the site's google results. Currently it is missing a nice company name.
* Also added `NailSalon` structured data - this should also cause the site to appear in certain other search contexts (e.g. local business searches) and display useful info such as opening hours.
* tweaked page title/description meta to improve SEO performance

# Testing

Unfortunately there's no reliable way to preview what a SERP listing looks like; amongst other things, structured data is largely considered as suggestions and may be overridden by Google. Must verify manually after changes are deployed and Google re-indexes the site.

Have verified that the JSON-LD is correctly being added to the page body:

![Screenshot 2023-10-01 at 8 42 06 pm](https://github.com/bootlegneurons/tdn-web-next/assets/37989995/6f983aaf-eda9-4209-ac3c-5f59c7270bec)
